### PR TITLE
Added more cores to Prokka specification

### DIFF
--- a/tool_destinations.yaml
+++ b/tool_destinations.yaml
@@ -772,6 +772,7 @@ prokka:
   env:
     _JAVA_OPTIONS: -XX:MaxPermSize=2G -Xmx15G -Xms1G -Djava.io.tmpdir=/data/2/galaxy_db/tmp
   mem: 20
+  cores: 8
 proteomics_search_msgfplus_1: {mem: 10}
 pyprophet_score: {mem: 800, cores: 1}
 pureclip: {mem: 32, cores: 2}


### PR DESCRIPTION
Prokka is able to send all of its sub tools the number of cores assigned to it. Most of them are very parallelisable. On Aus we run ~8 cores for Prokka jobs.